### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/backend/fr_pack/frpacker.cpp
+++ b/backend/fr_pack/frpacker.cpp
@@ -513,6 +513,7 @@ void BestPackerFrontEnd::DoPack(PackerCallback cb)
   }
 
   delete[] tokens;
+  delete[] links;
 }
 
 BestPackerFrontEnd::BestPackerFrontEnd(PackerBackEnd *backEnd)

--- a/backend/lzma/lzma.cpp
+++ b/backend/lzma/lzma.cpp
@@ -40,9 +40,11 @@ BYTE *Load_Input_File(char *FileName, DWORD *Size)
 
 	Memory = (BYTE *)malloc(*Size);
 	if (!Memory) return(NULL);
-	if (fread(Memory, 1, *Size, Input) != (size_t)*Size) return(NULL);
-	if (Input) fclose(Input);
-	Input = NULL;
+	if (fread(Memory, 1, *Size, Input) != (size_t)*Size) {
+		free(Memory);
+		return(NULL);
+	}
+	fclose(Input);
 	return(Memory);
 }
 


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V547](https://www.viva64.com/en/w/v547/) Expression 'Input' is always true. lzma.cpp 44
[V773](https://www.viva64.com/en/w/v773/) Visibility scope of the 'links' pointer was exited without releasing the memory. A memory leak is possible. frpacker.cpp 516
[V773](https://www.viva64.com/en/w/v773/) The function was exited without releasing the 'Memory' pointer. A memory leak is possible. lzma.cpp 43